### PR TITLE
Updated Docker Compose Configuration to Remove Obsolete Version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   iris:
     build:

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="dc-sample.ZPM">
     <Module>
       <Name>dc-sample</Name>
-      <Version>2.0.4</Version>
+      <Version>2.0.5</Version>
       <Description>Basic InterSystems IRIS Development Template</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="dc-sample.ZPM">
     <Module>
       <Name>dc-sample</Name>
-      <Version>2.0.3</Version>
+      <Version>2.0.4</Version>
       <Description>Basic InterSystems IRIS Development Template</Description>
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>


### PR DESCRIPTION
This pull request aims to resolve the issue #17 where docker instance execution is throwing an warning about version being obsolete. The problem is due to the usage of outdated Docker Compose version, which has been removed in newer versions.